### PR TITLE
Change dropdown menu event from onFocus to onClick

### DIFF
--- a/src/components/Headerbar/dropdownMenu.tsx
+++ b/src/components/Headerbar/dropdownMenu.tsx
@@ -31,7 +31,7 @@ export default function DropdownMenu ({ children, style, menuOptions }: Props) {
                 ))}
               </MenuContainer>
               </div>
-              : <Button onFocus={handleClick} style={{ cursor: 'pointer' }}
+              : <Button onClick={handleClick} style={{ cursor: 'pointer' }}
               > {children}</Button>
             }
           </OutsideClickHandler>


### PR DESCRIPTION
Change dropdown menu event from onFocus to onClick in an attempt to fix the blog post menu opening on mobile